### PR TITLE
docs: add validate step in module test workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ permissions:
   contents: read
 
 jobs:
-  terraform-lint:
+  terraform-lint-validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -58,9 +58,11 @@ jobs:
           curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
       - name: Run TFLint
         run: tflint --chdir "./src"
+      - name: Terraform Validate
+        run: terraform -chdir="./src" validate
 
   run-tests:
-    needs: terraform-lint
+    needs: terraform-lint-validate
     uses: infraweave-io/actions/.github/workflows/test-module.yaml@ba8503ab8b218417c1b1f42756c2ccadb1815f9a # v0.0.80
     with:
       central_account_id: "000000000000" # Modify this (recommended to use a variable)


### PR DESCRIPTION
This pull request updates the CI workflow for Terraform by renaming and enhancing the `terraform-lint` job to include a validation step, and by adjusting dependencies accordingly.

This prevents invalid modules from being published which would otherwise cause extra work to remove stuck deployments later.

### Changes to Terraform CI Workflow:

* **Job Renaming:**
  - Renamed the `terraform-lint` job to `terraform-lint-validate` for better clarity.

* **Validation Step Addition:**
  - Added a `Terraform Validate` step to the `terraform-lint-validate` job, which runs `terraform validate` to ensure configuration correctness.

* **Dependency Update:**
  - Updated the `run-tests` job to depend on the renamed `terraform-lint-validate` job instead of the old `terraform-lint` job. 